### PR TITLE
ILogger added to the DimService

### DIFF
--- a/AzureFunctionWithEF.Test/Repositories/DimAccountRepositoryTest.cs
+++ b/AzureFunctionWithEF.Test/Repositories/DimAccountRepositoryTest.cs
@@ -27,51 +27,52 @@ namespace AzureFunctionWithEF.Test.Repositories
             _dbContext = new Mock<MyDbContext>();
         }
 
-        [Test]
-        [Ignore("This is a repository, it should not be tested")]
-        public void ReturnMissingListFromSql_Test()
-        {
-            var myRepo = new DimAccountRepository(_dbContext.Object);
+        //[Test]
+        //[Ignore("This is a repository, it should not be tested")]
+        //public void ReturnMissingListFromSql_Test()
+        //{
+        //    var myRepo = new DimAccountRepository(_dbContext.Object);
             
-            var configToken = ConfigureEnvironmentVariablesFromLocalSettings();
+        //    var configToken = ConfigureEnvironmentVariablesFromLocalSettings();
 
-            string connectionString = ReturnConnectionString(configToken);
+        //    string connectionString = ReturnConnectionString(configToken);
 
-            var result = myRepo.ReturnMissingListFromSql(ref connectionString);
+        //    var result = myRepo.ReturnMissingListFromSql(ref connectionString, out int sqlValue);
 
-            Assert.IsNotNull(result);
-        }
+        //    Assert.IsNotNull(result);
+        //    Assert.AreEqual(1, sqlValue);
+        //}
 
-        #region Private methods
-        private static string ReturnConnectionString(IEnumerable<JToken> jTokenValues)
-        {
-            var cnxString = string.Empty;
-            for (int i = 0; i < jTokenValues.Count(); i++)
-            {
-                var str1 = jTokenValues.ElementAt(i);
+        //#region Private methods
+        //private static string ReturnConnectionString(IEnumerable<JToken> jTokenValues)
+        //{
+        //    var cnxString = string.Empty;
+        //    for (int i = 0; i < jTokenValues.Count(); i++)
+        //    {
+        //        var str1 = jTokenValues.ElementAt(i);
 
-                foreach (JProperty attributeProperty in str1)
-                {
-                    if (attributeProperty.Name == "SqlConnectionString")
-                    {
-                        var attribute = str1[attributeProperty.Name];
-                        cnxString = attribute.ToString();
-                    }
-                }
-            }
+        //        foreach (JProperty attributeProperty in str1)
+        //        {
+        //            if (attributeProperty.Name == "SqlConnectionString")
+        //            {
+        //                var attribute = str1[attributeProperty.Name];
+        //                cnxString = attribute.ToString();
+        //            }
+        //        }
+        //    }
 
-            return cnxString;
-        }
+        //    return cnxString;
+        //}
 
-        private static IEnumerable<JToken> ConfigureEnvironmentVariablesFromLocalSettings()
-        {
-            var path = Path.GetDirectoryName(typeof(DimAccountRepository)
-                .Assembly.Location); 
-            var json = File.ReadAllText(Path.Join(path, "local.settings.json"));
-            var parsed = Newtonsoft.Json.Linq.JObject.Parse(json).Values();
+        //private static IEnumerable<JToken> ConfigureEnvironmentVariablesFromLocalSettings()
+        //{
+        //    var path = Path.GetDirectoryName(typeof(DimAccountRepository)
+        //        .Assembly.Location); 
+        //    var json = File.ReadAllText(Path.Join(path, "local.settings.json"));
+        //    var parsed = Newtonsoft.Json.Linq.JObject.Parse(json).Values();
 
-            return parsed;
-        }
-        #endregion
+        //    return parsed;
+        //}
+        //#endregion
     }
 }

--- a/AzureFunctionWithEF/Repositories/DimAccountRepository.cs
+++ b/AzureFunctionWithEF/Repositories/DimAccountRepository.cs
@@ -41,7 +41,7 @@ namespace AzureFunctionWithEF.Repositories
         /// </summary>
         /// <param name="cnxString"></param>
         /// <returns></returns>
-        public List<string> ReturnMissingListFromSql(ref string cnxString)
+        public List<string> ReturnMissingListFromSql(ref string cnxString, out int sqlValue)
         {
             List<string> myList = new List<string>();
             SqlConnection connection;
@@ -69,6 +69,7 @@ namespace AzureFunctionWithEF.Repositories
             adapter = new SqlDataAdapter(command);
             adapter.Fill(ds);
 
+            sqlValue = (ds.Tables[0].Rows.Count > 0) ? 1 : 0;
 
             int i;
             for (i = 0; i <= ds.Tables[0].Rows.Count - 1; i++)

--- a/AzureFunctionWithEF/Repositories/IDimAccountRepository.cs
+++ b/AzureFunctionWithEF/Repositories/IDimAccountRepository.cs
@@ -6,7 +6,7 @@ namespace AzureFunctionWithEF.Repositories
 {
     public interface IDimAccountRepository
     {
-        List<string> ReturnMissingListFromSql(ref string cnxString);
+        List<string> ReturnMissingListFromSql(ref string cnxString, out int sqlValue);
         Task<List<DimAccount>> ReturnMissingFields();
     }
 }

--- a/AzureFunctionWithEF/host.json
+++ b/AzureFunctionWithEF/host.json
@@ -1,11 +1,14 @@
 {
-    "version": "2.0",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            }
-        }
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "Default": "Information"
+    },
+    "applicationInsights": {
+      "samplingExcludedTypes": "Request",
+      "samplingSettings": {
+        "isEnabled": true
+      }
     }
+  }
 }


### PR DESCRIPTION
.NET supports a logging API that works with a variety of built-in and third-party logging providers. This article shows how to use the logging API with built-in providers. Most of the code examples shown in this article apply to any .NET app that uses the [Generic Host](https://docs.microsoft.com/en-us/dotnet/core/extensions/generic-host). For apps that don't use the Generic Host, see [Non-host console app](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line#non-host-console-app).